### PR TITLE
[TECH] Introduce dependency injection via application object (DO NOT MERGE)

### DIFF
--- a/app/src/e2eTest/java/uk/nhs/digital/docstore/helpers/RequestEventBuilder.java
+++ b/app/src/e2eTest/java/uk/nhs/digital/docstore/helpers/RequestEventBuilder.java
@@ -1,0 +1,18 @@
+package uk.nhs.digital.docstore.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+
+import java.util.HashMap;
+
+public class RequestEventBuilder {
+    private final HashMap<String, String> parameters = new HashMap<>();
+
+    public RequestEventBuilder addQueryParameter(String name, String value) {
+        parameters.put(name, value);
+        return this;
+    }
+
+    public APIGatewayProxyRequestEvent build() {
+        return new APIGatewayProxyRequestEvent().withQueryStringParameters(parameters);
+    }
+}

--- a/app/src/main/java/uk/nhs/digital/docstore/Application.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/Application.java
@@ -1,0 +1,32 @@
+package uk.nhs.digital.docstore;
+
+import uk.nhs.digital.docstore.data.repository.DocumentMetadataStore;
+import uk.nhs.digital.docstore.data.repository.DocumentZipTraceStore;
+import uk.nhs.digital.docstore.filestorage.GeneratePresignedUrlRequestFactory;
+import uk.nhs.digital.docstore.patientdetails.PdsFhirClient;
+import uk.nhs.digital.docstore.patientdetails.RealPdsFhirClient;
+import uk.nhs.digital.docstore.publishers.AuditPublisher;
+import uk.nhs.digital.docstore.publishers.SplunkPublisher;
+
+public class Application {
+    public DocumentMetadataStore documentMetadataStore;
+
+    public DocumentZipTraceStore documentZipTraceStore;
+
+    public PdsFhirClient pdsFhirClient;
+
+    public DocumentStore documentStore;
+
+    public GeneratePresignedUrlRequestFactory generatePresignedUrlRequestFactory;
+    public AuditPublisher auditPublisher;
+
+    public Application () {
+        var env = System.getenv();
+        this.documentMetadataStore = new DocumentMetadataStore(env.getOrDefault("DYNAMODB_ENDPOINT", ""));
+        this.documentZipTraceStore = new DocumentZipTraceStore(env.getOrDefault("DYNAMODB_ENDPOINT", ""));
+        this.generatePresignedUrlRequestFactory = new GeneratePresignedUrlRequestFactory(env.get("DOCUMENT_STORE_BUCKET_NAME"));
+        this.pdsFhirClient = new RealPdsFhirClient(env.get("PDS_FHIR_ENDPOINT"));
+        this.documentStore = new DocumentStore(env.getOrDefault("S3_ENDPOINT", ""), "true".equals(System.getenv("S3_USE_PATH_STYLE")));
+        this.auditPublisher = new SplunkPublisher();
+    }
+}

--- a/app/src/main/java/uk/nhs/digital/docstore/CreateDocumentReferenceHandler.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/CreateDocumentReferenceHandler.java
@@ -40,7 +40,7 @@ public class CreateDocumentReferenceHandler implements RequestHandler<APIGateway
     private static final String SUBJECT_ID_CODING_SYSTEM = "https://fhir.nhs.uk/Id/nhs-number";
 
     private final DocumentReferenceService documentReferenceService = new DocumentReferenceService(
-            new DocumentMetadataStore(),
+            new DocumentMetadataStore(System.getenv("DYNAMODB_ENDPOINT")),
             System.getenv("DOCUMENT_STORE_BUCKET_NAME")
     );
 

--- a/app/src/main/java/uk/nhs/digital/docstore/DocumentUploadedEventHandler.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/DocumentUploadedEventHandler.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.nhs.digital.docstore.config.Tracer;
 import uk.nhs.digital.docstore.data.entity.DocumentMetadata;
-import uk.nhs.digital.docstore.data.repository.DocumentMetadataStore;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.List;
 public class DocumentUploadedEventHandler implements RequestHandler<S3Event, Void> {
     private static final Logger LOGGER = LoggerFactory.getLogger(DocumentUploadedEventHandler.class);
 
-    private final DocumentMetadataStore metadataStore = new DocumentMetadataStore();
+    private final Application application = new Application();
 
     @Override
     public Void handleRequest(S3Event event, Context context) {
@@ -32,12 +31,12 @@ public class DocumentUploadedEventHandler implements RequestHandler<S3Event, Voi
             String objectKey = s3.getObject().getKey();
             String location = String.format("s3://%s/%s", bucketName, objectKey);
 
-            DocumentMetadata metadata = metadataStore.getByLocation(location);
+            DocumentMetadata metadata = application.documentMetadataStore.getByLocation(location);
             metadata.setDocumentUploaded(true);
             metadata.setIndexed(Instant.now().toString());
 
             LOGGER.debug("Updating DocumentReference {} to uploaded", metadata.getId());
-            metadataStore.save(metadata);
+            application.documentMetadataStore.save(metadata);
         });
         return null;
     }

--- a/app/src/main/java/uk/nhs/digital/docstore/data/repository/DocumentMetadataStore.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/data/repository/DocumentMetadataStore.java
@@ -10,6 +10,10 @@ import java.util.Map;
 
 public class DocumentMetadataStore extends DynamoDbConnection {
 
+    public DocumentMetadataStore(String dynamodbEndpoint) {
+        super(dynamodbEndpoint);
+    }
+
     public DocumentMetadata getById(String id) {
         return mapper.load(DocumentMetadata.class, id);
     }

--- a/app/src/main/java/uk/nhs/digital/docstore/data/repository/DocumentZipTraceStore.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/data/repository/DocumentZipTraceStore.java
@@ -5,6 +5,10 @@ import uk.nhs.digital.docstore.utils.CommonUtils;
 
 public class DocumentZipTraceStore extends DynamoDbConnection {
 
+    public DocumentZipTraceStore(String dynamodbEndpoint) {
+        super(dynamodbEndpoint);
+    }
+
     public void save(DocumentZipTrace documentTrace) {
         if (documentTrace.getId() == null) {
             documentTrace.setId(CommonUtils.generateRandomUUIDString());

--- a/app/src/main/java/uk/nhs/digital/docstore/data/repository/DynamoDbConnection.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/data/repository/DynamoDbConnection.java
@@ -14,8 +14,8 @@ public class DynamoDbConnection {
 
     protected final DynamoDBMapper mapper;
 
-    public DynamoDbConnection() {
-        var dynamodbClient = getDynamodbClient();
+    public DynamoDbConnection(String dynamodbEndpoint) {
+        var dynamodbClient = getDynamodbClient(dynamodbEndpoint);
         this.mapper = new DynamoDBMapper(
                 dynamodbClient,
                 DynamoDBMapperConfig.builder()
@@ -23,14 +23,13 @@ public class DynamoDbConnection {
                         .build());
     }
 
-    private AmazonDynamoDB getDynamodbClient() {
+    private AmazonDynamoDB getDynamodbClient(String dynamodbEndpoint) {
         var clientBuilder = AmazonDynamoDBClientBuilder.standard();
-        var dynamodbEndpoint = System.getenv("DYNAMODB_ENDPOINT");
         if (!dynamodbEndpoint.equals(DEFAULT_ENDPOINT)) {
-            clientBuilder = clientBuilder.withEndpointConfiguration(new AwsClientBuilder
-                    .EndpointConfiguration(dynamodbEndpoint, AWS_REGION));
+            return clientBuilder
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(dynamodbEndpoint, AWS_REGION))
+                    .build();
         }
-        var dynamodbClient = clientBuilder.build();
-        return dynamodbClient;
+        return clientBuilder.build();
     }
 }

--- a/app/src/main/java/uk/nhs/digital/docstore/documentmanifest/CreateDocumentManifestByNhsNumberHandler.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/documentmanifest/CreateDocumentManifestByNhsNumberHandler.java
@@ -1,7 +1,5 @@
 package uk.nhs.digital.docstore.documentmanifest;
 
-import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.context.PerformanceOptionsEnum;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
@@ -10,13 +8,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+import uk.nhs.digital.docstore.Application;
 import uk.nhs.digital.docstore.DocumentStore;
 import uk.nhs.digital.docstore.ErrorResponseGenerator;
 import uk.nhs.digital.docstore.config.ApiConfig;
 import uk.nhs.digital.docstore.config.Tracer;
 import uk.nhs.digital.docstore.data.entity.DocumentZipTrace;
-import uk.nhs.digital.docstore.data.repository.DocumentMetadataStore;
-import uk.nhs.digital.docstore.data.repository.DocumentZipTraceStore;
 import uk.nhs.digital.docstore.utils.CommonUtils;
 import uk.nhs.digital.docstore.utils.DocumentMetadataSearchService;
 import uk.nhs.digital.docstore.utils.ZipService;
@@ -33,30 +30,26 @@ public class CreateDocumentManifestByNhsNumberHandler implements RequestHandler<
     private static final String DOCUMENT_TYPE_CODING_SYSTEM = "http://snomed.info/sct";
 
     private final String bucketName = System.getenv("DOCUMENT_STORE_BUCKET_NAME");
-    private final DocumentMetadataStore metadataStore = new DocumentMetadataStore();
-    private final DocumentZipTraceStore zipTraceStore = new DocumentZipTraceStore();
-    private final DocumentStore documentStore = new DocumentStore(bucketName);
+    private final DocumentStore documentStore = new DocumentStore(System.getenv("S3_ENDPOINT"), "true".equals(System.getenv("S3_USE_PATH_STYLE")));
     private final ErrorResponseGenerator errorResponseGenerator = new ErrorResponseGenerator();
-    private final FhirContext fhirContext;
-    private final ApiConfig apiConfig;
-    private final DocumentMetadataSearchService searchService = new DocumentMetadataSearchService(metadataStore);
     private final CommonUtils utils = new CommonUtils();
     private final ZipService zipService = new ZipService();
+    private final Application app;
 
     public CreateDocumentManifestByNhsNumberHandler() {
-        this(new ApiConfig());
+        this(new Application());
     }
 
-    public CreateDocumentManifestByNhsNumberHandler(ApiConfig apiConfig) {
-        this.fhirContext = FhirContext.forR4();
-        this.fhirContext.setPerformanceOptions(PerformanceOptionsEnum.DEFERRED_MODEL_SCANNING);
-        this.apiConfig = apiConfig;
+    public CreateDocumentManifestByNhsNumberHandler(Application application) {
+        this.app = application;
     }
 
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent requestEvent, Context context) {
         Tracer.setMDCContext(context);
 
         logger.debug("API Gateway event received - processing starts");
+
+        var searchService = new DocumentMetadataSearchService(app.documentMetadataStore);
 
         try {
             var nhsNumber = utils.getNhsNumberFrom(requestEvent.getQueryStringParameters());
@@ -68,16 +61,16 @@ public class CreateDocumentManifestByNhsNumberHandler implements RequestHandler<
             var documentPath = "tmp/" + CommonUtils.generateRandomUUIDString();
             var fileName = "patient-record-" + nhsNumber + ".zip";
 
-            documentStore.addDocument(documentPath, zipInputStream);
+            documentStore.addDocument(System.getenv("DOCUMENT_STORE_BUCKET_NAME"), documentPath, zipInputStream);
 
             var descriptor = new DocumentStore.DocumentDescriptor(bucketName, documentPath);
 
-            zipTraceStore.save(getDocumentZipTrace(descriptor.toLocation()));
+            app.documentZipTraceStore.save(getDocumentZipTrace(descriptor.toLocation()));
 
             var preSignedUrl = documentStore.generatePreSignedUrlForZip(descriptor, fileName);
             var body = getJsonBody(preSignedUrl.toString());
 
-            return apiConfig.getApiGatewayResponse(200, body, "GET", null);
+            return new ApiConfig().getApiGatewayResponse(200, body, "GET", null);
         } catch (Exception e) {
             return errorResponseGenerator.errorResponse(e);
         } catch (OutOfMemoryError outOfMemoryError) {

--- a/app/src/main/java/uk/nhs/digital/docstore/patientdetails/RealPdsFhirClient.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/patientdetails/RealPdsFhirClient.java
@@ -9,23 +9,23 @@ import uk.nhs.digital.docstore.patientdetails.fhirdtos.Patient;
 public class RealPdsFhirClient implements PdsFhirClient {
     private static final Logger logger = LoggerFactory.getLogger(RealPdsFhirClient.class);
 
-    private final PatientSearchConfig patientSearchConfig;
+    private final String pdsFhirEndpoint;
     private final SimpleHttpClient httpClient;
 
-    public RealPdsFhirClient(PatientSearchConfig patientSearchConfig) {
-        this(patientSearchConfig, new SimpleHttpClient());
+    public RealPdsFhirClient(String pdsFhirEndpoint) {
+        this(pdsFhirEndpoint, new SimpleHttpClient());
     }
 
-    public RealPdsFhirClient(PatientSearchConfig patientSearchConfig, SimpleHttpClient httpClient) {
-        this.patientSearchConfig = patientSearchConfig;
+    public RealPdsFhirClient(String pdsFhirEndpoint, SimpleHttpClient httpClient) {
+        this.pdsFhirEndpoint = pdsFhirEndpoint;
         this.httpClient = httpClient;
     }
 
     public Patient fetchPatientDetails(String nhsNumber) {
         var path = "Patient/" + nhsNumber;
 
-        logger.info("Confirming NHS number with PDS adaptor at " + patientSearchConfig.pdsFhirRootUri());
-        var response = httpClient.get(patientSearchConfig.pdsFhirRootUri(), path);
+        logger.info("Confirming NHS number with PDS adaptor at " + pdsFhirEndpoint);
+        var response = httpClient.get(pdsFhirEndpoint, path);
 
         if (response.statusCode() == 200) {
             return Patient.parseFromJson(response.body());

--- a/app/src/main/java/uk/nhs/digital/docstore/utils/ZipService.java
+++ b/app/src/main/java/uk/nhs/digital/docstore/utils/ZipService.java
@@ -17,8 +17,7 @@ public class ZipService {
     private final DocumentStore documentStore;
 
     public ZipService() {
-       var bucketName = System.getenv("DOCUMENT_STORE_BUCKET_NAME");
-       documentStore = new DocumentStore(bucketName);
+       documentStore = new DocumentStore(System.getenv("S3_ENDPOINT"), "true".equals(System.getenv("S3_USE_PATH_STYLE")));
     }
 
     public ZipService(DocumentStore documentStore) {
@@ -34,7 +33,7 @@ public class ZipService {
             if (metadata.isDocumentUploaded()){
                 zipOutputStream.putNextEntry(new ZipEntry(metadata.getDescription()));
 
-                IOUtils.copy(documentStore.getObjectFromS3(metadata), zipOutputStream);
+                IOUtils.copy(documentStore.getObjectFromS3(DocumentStore.DocumentDescriptor.from(metadata)), zipOutputStream);
 
                 zipOutputStream.closeEntry();
             }

--- a/app/src/test/java/uk/nhs/digital/docstore/data/DocumentMetadataStoreTest.java
+++ b/app/src/test/java/uk/nhs/digital/docstore/data/DocumentMetadataStoreTest.java
@@ -13,7 +13,7 @@ class DocumentMetadataStoreTest {
 
     @BeforeEach
     void setUp() {
-        store = new DocumentMetadataStore();
+        store = new DocumentMetadataStore("test.uri");
     }
 
     @Test

--- a/app/src/test/java/uk/nhs/digital/docstore/patientdetails/RealPdsFhirClientTest.java
+++ b/app/src/test/java/uk/nhs/digital/docstore/patientdetails/RealPdsFhirClientTest.java
@@ -35,8 +35,7 @@ class RealPdsFhirClientTest {
     public void shouldMakeCallToPdsAndReturnPatientDetailsWhenPdsFhirReturns200() {
         var testLogappender = TestLogAppender.addTestLogAppender();
 
-        var stubbingOffPatientSearchConfig = new StubbingOffPatientSearchConfig();
-        var pdsFhirClient = new RealPdsFhirClient(stubbingOffPatientSearchConfig, httpClient);
+        var pdsFhirClient = new RealPdsFhirClient("test.url", httpClient);
 
         String nhsNumber = "9000000009";
 
@@ -45,15 +44,14 @@ class RealPdsFhirClientTest {
         pdsFhirClient.fetchPatientDetails(nhsNumber);
 
         verify(httpClient).get(any(), contains(nhsNumber));
-        assertThat(testLogappender.findLoggedEvent(stubbingOffPatientSearchConfig.pdsFhirRootUri())).isNotNull();
+        assertThat(testLogappender.findLoggedEvent("test.url")).isNotNull();
     }
 
     @Test
     public void shouldMakeCallToPdsAndThrowExceptionWhenPdsFhirReturns400() {
         var testLogappender = TestLogAppender.addTestLogAppender();
 
-        var stubbingOffPatientSearchConfig = new StubbingOffPatientSearchConfig();
-        var pdsFhirClient = new RealPdsFhirClient(stubbingOffPatientSearchConfig, httpClient);
+        var pdsFhirClient = new RealPdsFhirClient("test.url", httpClient);
 
         when(httpClient.get(any(), any())).thenReturn(new StubPdsResponse(400, null));
 
@@ -62,15 +60,14 @@ class RealPdsFhirClientTest {
         assertThrows(InvalidResourceIdException.class,() -> pdsFhirClient.fetchPatientDetails(nhsNumber));
 
         verify(httpClient).get(any(), contains(nhsNumber));
-        assertThat(testLogappender.findLoggedEvent(stubbingOffPatientSearchConfig.pdsFhirRootUri())).isNotNull();
+        assertThat(testLogappender.findLoggedEvent("test.url")).isNotNull();
     }
 
     @Test
     public void shouldMakeCallToPdsAndThrowExceptionWhenPdsFhirReturns404() {
         var testLogappender = TestLogAppender.addTestLogAppender();
 
-        var stubbingOffPatientSearchConfig = new StubbingOffPatientSearchConfig();
-        var pdsFhirClient = new RealPdsFhirClient(stubbingOffPatientSearchConfig, httpClient);
+        var pdsFhirClient = new RealPdsFhirClient("test.url", httpClient);
 
         when(httpClient.get(any(), any())).thenReturn(new StubPdsResponse(404, null));
 
@@ -79,15 +76,14 @@ class RealPdsFhirClientTest {
         assertThrows(PatientNotFoundException.class,() -> pdsFhirClient.fetchPatientDetails(nhsNumber), "Patient does not exist for given NHS number.");
 
         verify(httpClient).get(any(), contains(nhsNumber));
-        assertThat(testLogappender.findLoggedEvent(stubbingOffPatientSearchConfig.pdsFhirRootUri())).isNotNull();
+        assertThat(testLogappender.findLoggedEvent("test.url")).isNotNull();
     }
 
     @Test
     public void shouldMakeCallToPdsAndThrowExceptionWhenPdsFhirReturnsAnyOtherErrorCode() {
         var testLogappender = TestLogAppender.addTestLogAppender();
 
-        var stubbingOffPatientSearchConfig = new StubbingOffPatientSearchConfig();
-        var pdsFhirClient = new RealPdsFhirClient(stubbingOffPatientSearchConfig, httpClient);
+        var pdsFhirClient = new RealPdsFhirClient("test.url", httpClient);
 
         when(httpClient.get(any(), any())).thenReturn(new StubPdsResponse(500, null));
 
@@ -96,7 +92,7 @@ class RealPdsFhirClientTest {
         assertThrows(RuntimeException.class,() -> pdsFhirClient.fetchPatientDetails(nhsNumber), "Got an error when requesting patient from PDS: 500");
 
         verify(httpClient).get(any(), contains(nhsNumber));
-        assertThat(testLogappender.findLoggedEvent(stubbingOffPatientSearchConfig.pdsFhirRootUri())).isNotNull();
+        assertThat(testLogappender.findLoggedEvent("test.url")).isNotNull();
     }
 
     private String getJSONPatientDetails(String nhsNumber) {
@@ -170,13 +166,6 @@ class RealPdsFhirClientTest {
         @Override
         public HttpClient.Version version() {
             return null;
-        }
-    }
-
-    private class StubbingOffPatientSearchConfig extends PatientSearchConfig {
-        @Override
-        public boolean pdsFhirIsStubbed() {
-            return false;
         }
     }
 }


### PR DESCRIPTION
Hi all, I created this branch as a POC to provide a few ideas for how we might want to go about improving our dependency injection capabilities, which will mean good things for our code factoring and also for our ability to run the tests quickly and flexibly. I don't suggest trying to keep this up with main and then merging it, I suggest instead a new pair re-implements this very rough work properly using this for ideas if necessary. Here is @richardw-nhs feedback on the code so far:

- Group all 'magic properties' from across the application such as environment variable names at the top of just this class (literally before anything else at all in the class so they are as clear as possible). These should also be private and 'encoded' directly into the object graph rather than public and leaked back into the business classes (I may need to explain this with an example)

- Don't store a reference to the app in any of the handlers (ie remove private final Application application). Accept it as a ctor parameter still but pull the required dependencies (eg data store) immediately into private class members within ctor scope. This has two benefits: 1) it is immediately clear what dependencies are required by each handler; 2) it is a clean separation between instantiation of the object graph and the business logic of the handler (otherwise the inversion of control pattern leaks into the handler)

- Make some of the dependencies lazy initialised since they are not all required by every handler, eg the PDS client and document data store

- Make the distinction between the various 'layers' of the application clearer, eg services vs data stores and other third party integrations (SQS, PDS), so they are straightforward to override, eg through ctor injection. This will make it easy to construct tests (which I think is what you're referring to)

- S3 should be in here so that we can hide the bucket name etc