### PR TITLE
[PRMT-3796] replace links to Home page with links to Start page

### DIFF
--- a/e2eTest/cypress/e2e/upload.cy.js
+++ b/e2eTest/cypress/e2e/upload.cy.js
@@ -46,7 +46,7 @@ describe("Uploads docs and tests it looks OK", () => {
         cy.checkA11y(undefined, undefined, logAccessibilityViolations, false);
         cy.findByRole("button", { name: "Start Again" }).click();
 
-        cy.url().should("eq", Cypress.config("baseUrl") + "/home");
+        cy.url().should("eq", Cypress.config("baseUrl") + "/");
 
         cy.findByRole("link", { name: "Log Out" }).click();
         cy.url().should("eq", baseUrl + "/");

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -107,7 +107,7 @@ const AppRoutes = () => {
                         element={<PatientSummaryPage nextPage={UPLOAD_SUBMIT} />}
                     />
 
-                    <Route path={UPLOAD_SUBMIT} element={<UploadDocumentsPage nextPagePath={HOME} />} />
+                    <Route path={UPLOAD_SUBMIT} element={<UploadDocumentsPage nextPagePath={ROOT} />} />
                 </Route>
             </Route>
         </Routes>

--- a/ui/src/pages/noValidOrgsPage/NoValidOrgsPage.jsx
+++ b/ui/src/pages/noValidOrgsPage/NoValidOrgsPage.jsx
@@ -32,7 +32,7 @@ const NoValidOrgsPage = () => {
                 </li>
             </ul>
             <p>
-                <ButtonLink href="/home">Return to start page</ButtonLink>
+                <ButtonLink href="/">Return to start page</ButtonLink>
             </p>
         </>
     );

--- a/ui/src/pages/noValidOrgsPage/NoValidOrgsPage.test.jsx
+++ b/ui/src/pages/noValidOrgsPage/NoValidOrgsPage.test.jsx
@@ -9,7 +9,7 @@ describe("NoValidOrgsPage", () => {
         renderNoValidOrgsPage();
 
         expect(screen.getByRole("link", { name: "NHS National Service Desk" })).toHaveAttribute("href", helpDeskUrl);
-        expect(screen.getByRole("button", { name: "Return to start page" })).toHaveAttribute("href", "/home");
+        expect(screen.getByRole("button", { name: "Return to start page" })).toHaveAttribute("href", "/");
         expect(
             screen.getByRole("heading", { name: "You do not have a valid organisation to access this service" })
         ).toBeInTheDocument();

--- a/ui/src/pages/patientSummaryPage/patientSummaryPage.jsx
+++ b/ui/src/pages/patientSummaryPage/patientSummaryPage.jsx
@@ -15,7 +15,7 @@ export const PatientSummaryPage = ({ nextPage }) => {
     };
 
     if (!patientDetails) {
-        navigate(routes.HOME);
+        navigate(routes.ROOT);
     }
 
     return (

--- a/ui/src/pages/patientSummaryPage/patientSummaryPage.test.jsx
+++ b/ui/src/pages/patientSummaryPage/patientSummaryPage.test.jsx
@@ -108,9 +108,9 @@ describe("<PatientSummaryPage/>", () => {
             });
         });
 
-        it("navigates to home page when no patient details found", async () => {
+        it("navigates to Start page when no patient details found", async () => {
             const mockNavigate = jest.fn();
-            const expectedNextPage = "/home";
+            const expectedNextPage = "/";
 
             useNavigate.mockImplementation(() => mockNavigate);
 

--- a/ui/src/pages/searchResultsPage/SearchResultsPage.jsx
+++ b/ui/src/pages/searchResultsPage/SearchResultsPage.jsx
@@ -188,7 +188,7 @@ const SearchResultsPage = () => {
             )}
             {(submissionState === states.FAILED || submissionState === states.SUCCEEDED) && (
                 <p>
-                    <Link to="/home">Start Again</Link>
+                    <Link to="/">Start Again</Link>
                 </p>
             )}
         </>

--- a/ui/src/pages/searchResultsPage/SearchResultsPage.test.jsx
+++ b/ui/src/pages/searchResultsPage/SearchResultsPage.test.jsx
@@ -58,12 +58,12 @@ describe("<SearchResultsPage />", () => {
             expect(await screen.findByRole("link", { name: "Start Again" })).toBeInTheDocument();
         });
 
-        it("goes to home page when user clicks on start again button", async () => {
+        it("goes to Start page when user clicks on start again button", async () => {
             usePatientDetailsContext.mockReturnValue([buildPatientDetails(), jest.fn()]);
 
             renderSearchResultsPage();
 
-            expect(await screen.findByRole("link", { name: "Start Again" })).toHaveAttribute("href", "/home");
+            expect(await screen.findByRole("link", { name: "Start Again" })).toHaveAttribute("href", "/");
         });
 
         it("displays a loading spinner when a document search is in progress", async () => {


### PR DESCRIPTION
Left Home page file and route in case we need this page in future

Didn’t update OIDCAuthCallbackRouter.jsx as this is not used (we use AuthCallbackRouter) and will be removed during Cognito clean up I think